### PR TITLE
flowtype support + disable react sort-comp

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,11 @@ module.exports = {
     "commonjs": true
   },
   "rules": {
+    "flow-vars/define-flow-type": 1,
+    "flow-vars/use-flow-type": 1,
     "valid-jsdoc": 2,
+    "react/sort-comp": 0,
+
 
     "one-var": [2, {
       "uninitialized": "always",
@@ -25,6 +29,7 @@ module.exports = {
     "new-cap": [2, {"capIsNewExceptions": ["Iterable", "Seq", "Collection", "Map", "OrderedMap", "List", "Stack", "Set", "OrderedSet", "Record", "Range", "Repeat"]}]
   },
   "plugins": [
+    "flow-vars",
     "react",
     "babel"
   ],

--- a/index.js
+++ b/index.js
@@ -11,7 +11,15 @@ module.exports = {
     "flow-vars/define-flow-type": 1,
     "flow-vars/use-flow-type": 1,
     "valid-jsdoc": 2,
-    "react/sort-comp": 0,
+    "react/sort-comp": [1, {
+      order: [
+        'static-methods',
+        'lifecycle',
+        'props',
+        'everything-else',
+        'render'
+      ]
+    }]
 
 
     "one-var": [2, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-rainforest",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Rainforest Eslint Config",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "babel-eslint": "4.1.3",
     "eslint-config-airbnb": "0.1.0",
     "eslint-plugin-babel": "2.2.0",
+    "eslint-plugin-flow-vars": "^0.3.0",
     "eslint-plugin-react": "3.5.1"
   }
 }


### PR DESCRIPTION
Adds initial support for flowtypes. Also disables react sort-comp rule as it pushes down `props` and `state` types below everything else, while having them on top makes more sense. 
