### PR TITLE
update babel-eslint dependency and moved plugins to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "babel-eslint": "6.0.4"
   },
   "dependencies": {
-    "eslint-config-airbnb": "0.1.0"
+    "eslint-config-airbnb": "9.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-rainforest",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Rainforest Eslint Config",
   "main": "index.js",
   "repository": {
@@ -17,13 +17,13 @@
   },
   "homepage": "https://github.com/rainforestapp/eslint-config-rainforest#readme",
   "peerDependencies": {
-    "eslint": ">=1.0.0"
+    "eslint": "2.9.0",
+    "eslint-plugin-babel": "2.2.0",
+    "eslint-plugin-flow-vars": "0.3.0",
+    "eslint-plugin-react": "5.1.1",
+    "babel-eslint": "6.0.4"
   },
   "dependencies": {
-    "babel-eslint": "4.1.3",
-    "eslint-config-airbnb": "0.1.0",
-    "eslint-plugin-babel": "2.2.0",
-    "eslint-plugin-flow-vars": "^0.3.0",
-    "eslint-plugin-react": "3.5.1"
+    "eslint-config-airbnb": "0.1.0"
   }
 }


### PR DESCRIPTION
update babel-eslint version to fix "estraverse-fb" not found error.

Also moved plugin dependencies to `peerDependencies`, mirroring [airbnb](https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/package.json)

for more discussion on this see https://github.com/eslint/eslint/issues/2518

Also bumped airbnb config version, there has been a lot of updates since 0.1.0
https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/CHANGELOG.md
