### PR TITLE
Remove recommendation to turn off built in js / ts support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,15 +27,8 @@ add these to your settings file:
 }
 ```
 
-Also in projects that use flow, it's useful to install [flow for vscode](https://github.com/flowtype/flow-for-vscode) and turn off the built in typescript support because it will be confusing as it will show the inferred typescript types alongside flow on hover, follow the gif below:
-![](https://raw.githubusercontent.com/flowtype/flow-for-vscode/1ae5552d149bb41c8173dee552a2975b336e7beb/readme/flow-disable-tsc.gif)
+Also in projects that use flow, it's useful to install [flow for vscode](https://github.com/flowtype/flow-for-vscode)
 
-```
-{
-  "flow.useNPMPackagedFlow": true,
-  "flow.useLSP": true
-}
-```
 
 ## Webstorm
 


### PR DESCRIPTION
The flow extension seems to play nicely with the built in js / ts support so we don't need to turn them off anymore