### PR TITLE
Added a new file pattern for spec rules override to support specs in nested folders

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['**/__tests__/*.js'],
+      files: ['**/__tests__/*.js', "**/*.spec.js"],
       rules: {
         'import/first': 'off',
         // need to figure out how to make these work with mocks

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainforestqa/eslint-config",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Rainforest Eslint Config",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
The current file rule wasn't working for specs in a path like `/app/__tests__/Test/automatedTestCreate.spec.js`.