### PR TITLE
enforce radix arg for parseInt

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,6 +219,7 @@ module.exports = {
       },
     ],
     'getter-return': 'error',
+    radix: 'error',
   },
   overrides: [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainforestqa/eslint-config",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "description": "Rainforest Eslint Config",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Enforces the usage of the `radix` param https://eslint.org/docs/latest/rules/radix whenever `parseInt` is used