### PR TITLE
Enforce omitting .js extension in import

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,14 @@ module.exports = {
     'import/first': 'warn',
     'import/no-amd': 'error',
     'import/no-webpack-loader-syntax': 'error',
+    'import/extensions': [
+      'error',
+      'ignorePackages',
+      {
+        js: 'never',
+        ts: 'never',
+      },
+    ],
     // lots of our legacy code reexports a named export as default. There's no reason to do so and we should fix and enable this rule
     'import/no-named-as-default': 'warn',
     'import/namespace': ['error', { allowComputed: true }],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainforestqa/eslint-config",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Rainforest Eslint Config",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
For https://github.com/rainforestapp/regenwald/pull/12737

For forward compatibility, I've also include omission of `.ts` extension.